### PR TITLE
adblock-update

### DIFF
--- a/adblock-update.sh
+++ b/adblock-update.sh
@@ -1,18 +1,20 @@
 #!/bin/bash
 
+[[ -z "$XDG_DATA_HOME" ]] && DATADIR="$HOME/.local/share" || DATADIR="XDG_DATA_HOME"
+
 # look for adblock directory or fallback
-[[ -d ~/.local/share/luakit/adblock/ ]] && cd ~/.local/share/luakit/adblock/ || cd ~/.local/share/luakit/
+[[ -d $DATADIR/luakit/adblock/ ]] && cd $DATADIR/luakit/adblock/ || cd $DATADIR/luakit/
 
 # backup the old list
-[[ -f easylist.txt ]] && cp easylist.txt easylist.txt.b
+[[ -f easylist.txt ]] && cp -p easylist.txt easylist.txt.b
 
-wget -N --connect-timeout=10 --retry-connrefused --wait=5 https://easylist-downloads.adblockplus.org/easylist.txt
+wget -N --connect-timeout=10 --tries=20 --retry-connrefused --waitretry=5 https://easylist-downloads.adblockplus.org/easylist.txt
 
 # if download failed move old file back in place
-if [[ $? != 0 ]]; then
+if (( $? != 0 )); then
 	[[ -f easylist.txt.b ]] && mv easylist.txt.b easylist.txt
 	echo "Error: Easylist Download Failed!"
-	exit 1
+	exit 11
 else
 	[[ -f easylist.txt.b ]] && rm easylist.txt.b # if all went well remove backup
 	echo "All went well. :)"

--- a/adblock-update.sh
+++ b/adblock-update.sh
@@ -1,18 +1,20 @@
 #!/bin/bash
 
+# look for adblock directory or fallback
+[[ -d ~/.local/share/luakit/adblock/ ]] && cd ~/.local/share/luakit/adblock/ || cd ~/.local/share/luakit/
 
-[[ -d /tmp ]] && cd /tmp/
+# backup the old list
+[[ -f easylist.txt ]] && cp easylist.txt easylist.txt.b
 
-rm ./easylist.txt*
+wget -N --connect-timeout=10 --retry-connrefused --wait=5 https://easylist-downloads.adblockplus.org/easylist.txt
 
-while ! wget https://easylist-downloads.adblockplus.org/easylist.txt; do
-    sleep 0.2s;
-done;
-
-if [[ -d ~/.local/share/luakit/adblock/ ]]; then
-    mv ./easylist.txt ~/.local/share/luakit/adblock/;
+# if download failed move old file back in place
+if [[ $? != 0 ]]; then
+	[[ -f easylist.txt.b ]] && mv easylist.txt.b easylist.txt
+	echo "Error: Easylist Download Failed!"
+	exit 1
 else
-    mv ./easylist.txt ~/.local/share/luakit/;
-fi;
-
-exit
+	[[ -f easylist.txt.b ]] && rm easylist.txt.b # if all went well remove backup
+	echo "All went well. :)"
+	exit 0
+fi


### PR DESCRIPTION
New adblock-update script. 
It only downloads easylist if the file on the server is newer, 
retries and timeout are not infinite anymore and are specified by wget options, 
it creates a backup of the old easylist 
and moves it back in place if the download fails/is interrupted.

Edit: Afaik wget limits the retries to 20 by default.
